### PR TITLE
Fix - Glass Wave - Set Font Default Value

### DIFF
--- a/src/data/themes/glasswave.ts
+++ b/src/data/themes/glasswave.ts
@@ -131,7 +131,7 @@ const theme: Theme = {
                     props: {
                         variable: 'var-font',
                         index: 0,
-                        value: '',
+                        value: 'gg sans',
                         title: 'App font'
                     }
                 },


### PR DESCRIPTION
Sets Font Default Value to 'gg sans', was lelft blank.